### PR TITLE
Add backgroundColor prop for options

### DIFF
--- a/docs/components/props.js
+++ b/docs/components/props.js
@@ -53,6 +53,14 @@ const Props = () => {
           </tr>
           <tr>
             <td>
+              <a href='/docs-props/#example-2'>backgroundColor</a>
+            </td>
+            <td>String</td>
+            <td>#F0F0F0</td>
+            <td>Changes the background colour of the options in the list</td>
+          </tr>
+          <tr>
+            <td>
               <a href='/docs-props/#example-2'>className</a>
             </td>
             <td>String</td>

--- a/docs/props.mdx
+++ b/docs/props.mdx
@@ -89,6 +89,7 @@ const App = () => {
         style={{ margin: '10px' }}
         hightlighColor='#C6F6D5'
         selectedOptionColor='#68D391'
+        backgroundColor='#F0F0F0'
       />
     </div>
   )
@@ -259,12 +260,10 @@ const App = () => {
     <div>
       <ComboBox
         options={options}
-        renderRightElement={()=> <AiFillCaretDown /> }
-        renderLeftElement={()=> <AiFillFilter /> }
-
+        renderRightElement={() => <AiFillCaretDown />}
+        renderLeftElement={() => <AiFillFilter />}
       />
     </div>
   )
 }
 ```
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,7 @@ type ComboBoxProps = {
   popoverClassName?: string
   highlightColor?: string
   selectedOptionColor?: string
+  backgroundColor?: string
   enableAutocomplete?: boolean
   inputStyles?: React.CSSProperties
   name?: string
@@ -59,6 +60,7 @@ const ComboBox: React.FC<ComboBoxProps> = ({
   popoverClassName,
   highlightColor,
   selectedOptionColor,
+  backgroundColor,
   enableAutocomplete,
   inputStyles,
   name,
@@ -283,7 +285,7 @@ const ComboBox: React.FC<ComboBoxProps> = ({
       return highlightColor || '#bee3f8'
     } else if (optionIndex === selectedOptionIndex) {
       return selectedOptionColor || '#63b3ed'
-    } else return 'white'
+    } else return backgroundColor || 'white'
   }
 
   return (


### PR DESCRIPTION
Currently the background color of options is set to white and can't be changed.
This allows to change it similarly to the selectedOptioncolor/highlightColor props.