### PR TITLE
Fix peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dropdown"
   ],
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
Hooks were introduced in React `>=16.8.0` so it should be the minimum.
`<18.0.0` to also allow React 17 but don't allow 18 yet since there could be breaking changes.

This also fixes #5 